### PR TITLE
added encoding utf-8 when opening file (utils.py)

### DIFF
--- a/fontawesome_6/utils.py
+++ b/fontawesome_6/utils.py
@@ -19,7 +19,7 @@ def get_icon_choices():
         'light': 'fal',
     }
 
-    with open(os.path.join(os.path.dirname(__file__), path)) as f:
+    with open(os.path.join(os.path.dirname(__file__), path), encoding="utf-8") as f:
         icons = json.load(f)
 
     for icon in icons:


### PR DESCRIPTION
If the locale system-default is ASCII, the docker-build process of any project containing django-fontawesome-6 will fail.